### PR TITLE
CImageBoxExUI SetPos 大小不变的情况下不在创建销毁

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,17 @@
 
 
 *.svn
+/.vs/DuiEditor2019/v16
+*.dll
+*.pdb
+*.exe
+*.tlog
+*.obj
+*.log
+*.ilk
+*.pch
+*.lib
+*.recipe
+*.exp
+*.res
+*.idb

--- a/DuiLib/Control/UIImageBoxEx.cpp
+++ b/DuiLib/Control/UIImageBoxEx.cpp
@@ -110,8 +110,11 @@ void CImageBoxExUI::DoEvent(TEventUI& event)
 void CImageBoxExUI::SetPos(RECT rc, bool bNeedInvalidate)
 {
 	CControlUI::SetPos(rc, bNeedInvalidate);
-	m_pOffScreenImage->Destroy();
-	m_pOffScreenImage->Create(rc.right-rc.left, rc.bottom-rc.top, 24, 0);
+	if (m_pOffScreenImage->GetWidth() != (rc.right - rc.left) && m_pOffScreenImage->GetHeight() != (rc.bottom - rc.top))//add wenchangwei 2022-02-24
+	{
+		m_pOffScreenImage->Destroy();
+		m_pOffScreenImage->Create(rc.right - rc.left, rc.bottom - rc.top, 24, 0);
+	}
 }
 
 void CImageBoxExUI::Move(SIZE szOffset, bool bNeedInvalidate)


### PR DESCRIPTION
CImageBoxExUI SetPos 频繁销毁创建导致会出现闪烁问题